### PR TITLE
Update tag base format

### DIFF
--- a/process/src/ChangeLog.js
+++ b/process/src/ChangeLog.js
@@ -38,7 +38,7 @@ class ChangeLog {
   }
 
   versionNumberFromTag(tag) {
-    const version = tag.replace("OneLife_v", "");
+    const version = tag.replace("2HOL_v", "");
     if (version == "Start") return 0;
     return parseInt(version);
   }

--- a/process/src/ChangeLogVersion.js
+++ b/process/src/ChangeLogVersion.js
@@ -11,9 +11,9 @@ class ChangeLogVersion {
   }
 
   tag() {
-    if (this.id == 0) return "OneLife_vStart";
+    if (this.id == 0) return "2HOL_vStart";
     if (this.isUnreleased()) return "master";
-    return "OneLife_v" + this.id;
+    return "2HOL_v" + this.id;
   }
 
   populateObjects() {


### PR DESCRIPTION
Was getting a bunch of errors that were confusing me.

After hours of messing around, I found that updating the tag base format fixed the issue.

We recently changed our OneLifeData7 repo to be a fork of Jasons. We did this by forking Jasons repo, rolled back all changes since we last branched off (August 2019, roughly v256) and then dumped all our old git history on top of this.

But rolling back did not remove Jasons tags of versions beyond 256. I am blaming this as the likley root of the issue.